### PR TITLE
Fix contact nav scroll handler

### DIFF
--- a/src/components/nav/navbar.tsx
+++ b/src/components/nav/navbar.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { useState, FC } from "react";
 import { Transition } from "@headlessui/react";
 import { Link, navigate, PageProps } from "gatsby";
@@ -9,10 +10,10 @@ import { scroller } from "react-scroll";
 export const NavBar: FC<PageProps> = ({ location }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleContactClick = (e) => {
-    e.preventDefault();
+  const handleContactClick = (e?: React.MouseEvent<HTMLButtonElement>) => {
+    e?.preventDefault();
     if (location?.pathname === "/") {
-      scroller.scrollTo("contact-section", {
+      scroller.scrollTo("contact", {
         duration: 800,
         delay: 0,
         smooth: "easeInOutQuart",
@@ -42,7 +43,7 @@ export const NavBar: FC<PageProps> = ({ location }) => {
                       return (
                         <button
                           key={link.slug}
-                          onClick={handleContactClick}
+                          onClick={(e) => handleContactClick(e)}
                           className="font-inconsolata text-xl flex items-center h-full text-main-text hover:bg-highlight hover:text-white hover:bg-red-600 px-3 font-medium transition-all duration-300"
                         >
                           {link.label}
@@ -99,9 +100,9 @@ export const NavBar: FC<PageProps> = ({ location }) => {
                     return (
                       <button
                         key={item?.slug}
-                        onClick={() => {
+                        onClick={(e) => {
                           setIsOpen(false);
-                          handleContactClick();
+                          handleContactClick(e);
                         }}
                         className="cursor-pointer block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white"
                       >


### PR DESCRIPTION
## Summary
- make the contact nav handler accept the click event optionally and prevent default safely
- pass the click event from desktop and mobile buttons and scroll to the correct contact section id

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e101b44818832a944c7f4b1536ea78