### PR TITLE
Embed resume via PDF.js viewer

### DIFF
--- a/src/components/nav/navbar.tsx
+++ b/src/components/nav/navbar.tsx
@@ -1,4 +1,4 @@
-import { useState, FC } from "react";
+import { useState, FC, MouseEvent } from "react";
 import { Transition } from "@headlessui/react";
 import { Link, navigate, PageProps } from "gatsby";
 import { FaGreaterThan, FaHamburger, FaLessThan } from "react-icons/fa";
@@ -6,11 +6,15 @@ import { ImCross } from "react-icons/im";
 import { content } from "../../content/data";
 import { scroller } from "react-scroll";
 
+const isFileLink = (slug: string) => /\.(pdf|docx?)$/i.test(slug);
+
 export const NavBar: FC<PageProps> = ({ location }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleContactClick = (e) => {
-    e.preventDefault();
+  const handleContactClick = (
+    e?: MouseEvent<HTMLButtonElement | HTMLAnchorElement>,
+  ) => {
+    e?.preventDefault();
     if (location?.pathname === "/") {
       scroller.scrollTo("contact-section", {
         duration: 800,
@@ -38,7 +42,10 @@ export const NavBar: FC<PageProps> = ({ location }) => {
               <div className="h-full hidden md:block">
                 <div className="h-full flex items-baseline py-auto">
                   {content?.nav?.items.map((link) => {
-                    if (link?.label === "Contact") {
+                    const isContact = link?.label === "Contact";
+                    const fileLink = isFileLink(link.slug);
+
+                    if (isContact) {
                       return (
                         <button
                           key={link.slug}
@@ -47,6 +54,20 @@ export const NavBar: FC<PageProps> = ({ location }) => {
                         >
                           {link.label}
                         </button>
+                      );
+                    }
+
+                    if (fileLink) {
+                      return (
+                        <a
+                          key={link.slug}
+                          href={link.slug}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="font-inconsolata text-xl flex items-center h-full text-main-text hover:bg-highlight hover:text-white hover:bg-red-600 px-3 font-medium transition-all duration-300"
+                        >
+                          {link.label}
+                        </a>
                       );
                     }
 
@@ -95,7 +116,10 @@ export const NavBar: FC<PageProps> = ({ location }) => {
             <div className="md:hidden" id="mobile-menu">
               <div ref={ref} className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
                 {content.nav.items.map((item) => {
-                  if (item.label === "Contact") {
+                  const isContact = item.label === "Contact";
+                  const fileLink = isFileLink(item.slug);
+
+                  if (isContact) {
                     return (
                       <button
                         key={item?.slug}
@@ -107,6 +131,20 @@ export const NavBar: FC<PageProps> = ({ location }) => {
                       >
                         {item?.label}
                       </button>
+                    );
+                  }
+
+                  if (fileLink) {
+                    return (
+                      <a
+                        key={item.slug}
+                        href={item.slug}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white"
+                      >
+                        {item.label}
+                      </a>
                     );
                   }
 

--- a/src/content/data.ts
+++ b/src/content/data.ts
@@ -47,6 +47,10 @@ export const content: Type = {
         slug: "/blog",
       },
       {
+        label: "Resume",
+        slug: "/resume",
+      },
+      {
         label: "Contact",
         slug: "/contact",
       },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,7 @@ import { StaticImage } from "gatsby-plugin-image";
 import Typical from "react-typical";
 import { SEO } from "@components/seo"; // Ensure you have an SEO component
 import FloatingIcons from "@components/floating-icons";
-import { PageProps } from "gatsby";
+import { Link, PageProps } from "gatsby";
 import { scroller } from "react-scroll";
 
 export enum SECTIONS {
@@ -27,7 +27,6 @@ const Index: FC<PageProps<null, null, { scrollToContact: boolean }>> = ({
   }, []);
 
   useEffect(() => {
-    console.log("state", location.state);
     if (location.state && location.state.scrollToContact) {
       scroller.scrollTo(SECTIONS.CONTACT, {
         duration: 800,
@@ -37,6 +36,15 @@ const Index: FC<PageProps<null, null, { scrollToContact: boolean }>> = ({
       });
     }
   }, [location]);
+
+  const scrollToContactSection = () => {
+    scroller.scrollTo(SECTIONS.CONTACT, {
+      duration: 800,
+      delay: 0,
+      smooth: "easeInOutQuart",
+      offset: -50,
+    });
+  };
 
   const calculateAge = (dob: string) => {
     const today = new Date();
@@ -103,6 +111,21 @@ const Index: FC<PageProps<null, null, { scrollToContact: boolean }>> = ({
                   className="inline-block"
                 />
               </h1>
+              <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center md:justify-start">
+                <Link
+                  to="/resume"
+                  className="inline-flex items-center justify-center rounded-md bg-highlight px-8 py-3 text-lg font-semibold text-white transition duration-300 hover:bg-red-600"
+                >
+                  View Resume
+                </Link>
+                <button
+                  type="button"
+                  onClick={scrollToContactSection}
+                  className="inline-flex items-center justify-center rounded-md border-2 border-highlight px-8 py-3 text-lg font-semibold text-highlight transition duration-300 hover:bg-highlight hover:text-white"
+                >
+                  Contact Me
+                </button>
+              </div>
             </div>
           </div>
 
@@ -169,8 +192,8 @@ const Index: FC<PageProps<null, null, { scrollToContact: boolean }>> = ({
         headOrTail
       >
         <div className="flex-col pt-20 w-10/12 justify-center items-center mx-auto my-auto pl-4">
-          <h1 className=" font-mono" >
-            Ping me section
+          <h1 className="font-mono text-3xl font-bold text-main-text">
+            Get in Touch
           </h1>
         </div>
         <ContactForm />

--- a/src/pages/resume.tsx
+++ b/src/pages/resume.tsx
@@ -1,0 +1,54 @@
+import { FC } from "react";
+import { Layout } from "@components/layout";
+import { SEO } from "@components/seo";
+
+const PDF_URL =
+  "https://github.com/Notaduck/CV/releases/download/latest/DANIEL_GULDBERG_AAES_CV.pdf";
+const PDF_VIEWER_URL = "https://mozilla.github.io/pdf.js/web/viewer.html";
+const EMBED_SRC = `${PDF_VIEWER_URL}?file=${encodeURIComponent(PDF_URL)}`;
+
+const Resume: FC = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Resume"
+        description="Preview Daniel Guldberg Aaes' up-to-date resume directly on the page."
+      />
+      <div className="w-10/12 mx-auto py-12 font-montserrat text-main-text">
+        <header className="max-w-3xl mb-8">
+          <h1 className="text-4xl font-bold mb-3">Resume</h1>
+          <p className="text-lg text-secondary-text">
+            The embedded preview below always loads the latest published resume
+            from GitHub Releases. If your browser doesn&apos;t support inline PDF
+            previews, you can open the document in a new tab using the
+            supplemental link.
+          </p>
+        </header>
+
+        <div className="w-full rounded-lg border border-gray-200 shadow-sm overflow-hidden">
+          <iframe
+            src={EMBED_SRC}
+            title="Daniel Guldberg Aaes Resume"
+            className="w-full h-[80vh]"
+            loading="lazy"
+            allowFullScreen
+          />
+        </div>
+
+        <p className="mt-6 text-secondary-text">
+          Prefer a dedicated tab or need to download it?{' '}
+          <a
+            href={PDF_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-highlight font-semibold hover:underline"
+          >
+            Click here to open the PDF directly.
+          </a>
+        </p>
+      </div>
+    </Layout>
+  );
+};
+
+export default Resume;


### PR DESCRIPTION
## Summary
- route the resume iframe through the hosted PDF.js viewer so GitHub release assets display inline instead of downloading
- keep the direct download link available for users that prefer a standalone tab

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e102391e84832a954668322e165346