### PR TITLE
Update accent palette and focus styles

### DIFF
--- a/src/components/nav/navLink.tsx
+++ b/src/components/nav/navLink.tsx
@@ -16,13 +16,18 @@ export const NavLink: React.FC<Props> = ({ path, title }) => (
                m:text-base 
                font-medium 
                uppercase
-               px-px  
+               px-px
                text-main
                hover:underline
-               transition 
-               duration-150 
+               focus-visible:outline-none
+               focus-visible:ring-2
+               focus-visible:ring-accent
+               focus-visible:ring-offset-2
+               focus-visible:ring-offset-primary
+               transition
+               duration-150
                ease-in-out"
-    activeClassName="text-accent text-gray-900 hover:text-leather-light"
+    activeClassName="text-accent hover:text-highlight"
     partiallyActive={true}
   >
     {title}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,23 +5,23 @@
  	scroll-behavior: smooth;
  }
 
- .light {
- 	--primary: #ffffff;
- 	--secondary: #dbe1e8;
- 	--text-main: #0d0106;
- 	--text-secondary: #454e56;
- 	--highlight: rgb(188, 67, 93);
- 	--accent: #009ffd;
- }
+.light {
+        --primary: #ffffff;
+        --secondary: #dbe1e8;
+        --text-main: #0d0106;
+        --text-secondary: #454e56;
+        --highlight: rgb(188, 67, 93);
+        --accent: #a83252;
+}
 
- .dark {
- 	--primary: #06131c;
- 	--secondary: #2a2e35;
- 	--text-main: #d0cfc4;
- 	--highlight: rgb(188, 67, 93);
- 	--text-secondary: #b8b8b9;
- 	--accent: #fc7753;
- }
+.dark {
+        --primary: #06131c;
+        --secondary: #2a2e35;
+        --text-main: #d0cfc4;
+        --highlight: rgb(188, 67, 93);
+        --text-secondary: #b8b8b9;
+        --accent: #ff8a9a;
+}
 
  @tailwind base;
  @tailwind components;
@@ -62,11 +62,30 @@
  }
 
 
- a,
- p,
- span {
- 	@apply font-montserrat
- }
+a,
+p,
+span {
+        @apply font-montserrat
+}
+
+a {
+        color: var(--accent);
+        transition: color 150ms ease-in-out;
+}
+
+a:hover,
+a:focus {
+        color: var(--highlight);
+}
+
+a:focus-visible {
+        outline: 3px solid var(--accent);
+        outline-offset: 3px;
+}
+
+.b-accent {
+        border-color: var(--accent);
+}
 
  .gatsby-remark-prismjs-copy-button-container {
  	@apply left-4;


### PR DESCRIPTION
## Summary
- refresh the light and dark theme accent variables to warmer hues and add global link styles that use them
- provide accent-based hover and focus-visible outlines so interactive elements maintain contrast in both themes
- tighten nav link active and focus states with accent rings and highlight hovers for accessibility

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68e12a62af68832a8207b6b617e418d8